### PR TITLE
Add end notification of Arukas' beta service

### DIFF
--- a/website/arukas.erb
+++ b/website/arukas.erb
@@ -20,13 +20,5 @@
       </li>
     </ul>
   <% end %>
-
-  <div class="alert alert-warning" role="alert">
-    <strong>NOTE:</strong> Arukas' beta service will end on July 31, 2017.
-    After that, official service will be started(however, the release date is undecided).
-    We plan to upgrade this provider after official service starts.
-    Until that time, this provider will not be maintained.
-  </div>
-
   <%= yield %>
 <% end %>

--- a/website/arukas.erb
+++ b/website/arukas.erb
@@ -21,5 +21,12 @@
     </ul>
   <% end %>
 
+  <div class="alert alert-warning" role="alert">
+    <strong>NOTE:</strong> Arukas' beta service will end on July 31, 2017.
+    After that, official service will be started(however, the release date is undecided).
+    We plan to upgrade this provider after official service starts.
+    Until that time, this provider will not be maintained.
+  </div>
+
   <%= yield %>
 <% end %>

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,6 +8,11 @@ description: |-
 
 # Arukas Provider
 
+!> **NOTE:** Arukas' beta service will end on **July 31, 2017**.
+    After that, official service will be started (however, the release date is undecided).
+    We plan to upgrade this provider after official service starts.
+    Until that time, this provider will not be maintained.
+
 The Arukas provider is used to manage [Arukas](https://arukas.io/en/) resources.
 
 Use the navigation to the left to read about the available resources.


### PR DESCRIPTION
This PR adds the end notification of Arukas' beta service to the [provider's document page](https://www.terraform.io/docs/providers/arukas/index.html).