### PR TITLE
resource/arukas_container: fixed wrong value setting of endpoint_full_xxx attributes

### DIFF
--- a/arukas/resource_arukas_container.go
+++ b/arukas/resource_arukas_container.go
@@ -245,8 +245,8 @@ func resourceArukasContainerRead(d *schema.ResourceData, meta interface{}) error
 		endpoint = strings.Replace(endpoint, ".arukascloud.io", "", -1)
 	}
 	d.Set("endpoint", endpoint)
-	d.Set("endpoint_full_hostname", endpoint)
-	d.Set("endpoint_full_url", fmt.Sprintf("https://%s", endpoint))
+	d.Set("endpoint_full_hostname", service.EndPoint())
+	d.Set("endpoint_full_url", fmt.Sprintf("https://%s", service.EndPoint()))
 
 	d.Set("service_id", app.ServiceID())
 	return nil

--- a/arukas/resource_arukas_container_test.go
+++ b/arukas/resource_arukas_container_test.go
@@ -2,6 +2,7 @@ package arukas
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -49,6 +50,12 @@ func TestAccArukasContainer_Basic(t *testing.T) {
 						"arukas_container.foobar", "environments.0.value", "value"),
 					resource.TestCheckResourceAttr(
 						"arukas_container.foobar", "port_mappings.#", "1"),
+					resource.TestMatchResourceAttr(
+						"arukas_container.foobar", "endpoint_full_hostname", regexp.MustCompile(`^[\w-]+?\.arukascloud\.io$`),
+					),
+					resource.TestMatchResourceAttr(
+						"arukas_container.foobar", "endpoint_full_url", regexp.MustCompile(`^https://[\w-]+?\.arukascloud\.io$`),
+					),
 				),
 			},
 		},


### PR DESCRIPTION
This PR fixes wrong value setting of `endpoint_full_url` and `endpoint_full_hostname`.

It passed all acceptance tests as follows.

```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-arukas	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccArukasContainer_Basic
--- PASS: TestAccArukasContainer_Basic (14.63s)
=== RUN   TestAccArukasContainer_Update
--- PASS: TestAccArukasContainer_Update (29.32s)
=== RUN   TestAccArukasContainer_Minimum
--- PASS: TestAccArukasContainer_Minimum (15.05s)
=== RUN   TestAccArukasContainer_Import
--- PASS: TestAccArukasContainer_Import (8.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-arukas/arukas	67.035s
```