### PR TITLE
Upgrade go-arukas to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238 // indirect
 	github.com/posener/complete v0.0.0-20180119090745-cdc49b71388c // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
-	github.com/yamamoto-febc/go-arukas v0.0.8
+	github.com/yamamoto-febc/go-arukas v0.1.0
 	github.com/zclconf/go-cty v0.0.0-20180718220526-02bd58e97b57 // indirect
 	golang.org/x/crypto v0.0.0-20180219163459-432090b8f568 // indirect
 	golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnW
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557 h1:Jpn2j6wHkC9wJv5iMfJhKqrZJx3TahFx+7sbZ7zQdxs=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
-github.com/yamamoto-febc/go-arukas v0.0.8 h1:2ODyqSKl4MCWaCftVwvGTo/hV6OU8G+sI6vqCCoWjKk=
-github.com/yamamoto-febc/go-arukas v0.0.8/go.mod h1:jDgalLaoGEsU+HdUqj5B9kYCa+7aOmgS2GIEWb+Mn3I=
+github.com/yamamoto-febc/go-arukas v0.1.0 h1:IqHIITwT+5t3/uLPrqK+Yw9M+RVyTI98gTJ+Nt0cFlE=
+github.com/yamamoto-febc/go-arukas v0.1.0/go.mod h1:jDgalLaoGEsU+HdUqj5B9kYCa+7aOmgS2GIEWb+Mn3I=
 github.com/zclconf/go-cty v0.0.0-20180302160414-49fa5e03c418/go.mod h1:LnDKxj8gN4aatfXUqmUNooaDjvmDcLPbAN3hYBIVoJE=
 github.com/zclconf/go-cty v0.0.0-20180718220526-02bd58e97b57 h1:FWjfWQtNK83IJMe58FfMCSNkySe0PO9TvrQyLOKcPxw=
 github.com/zclconf/go-cty v0.0.0-20180718220526-02bd58e97b57/go.mod h1:LnDKxj8gN4aatfXUqmUNooaDjvmDcLPbAN3hYBIVoJE=

--- a/vendor/github.com/yamamoto-febc/go-arukas/.travis.yml
+++ b/vendor/github.com/yamamoto-febc/go-arukas/.travis.yml
@@ -1,9 +1,8 @@
 language: go
-go: "1.10"
+go: "1.12"
 
 install:
   - make tools
-  - dep init
 
 script:
   - make test

--- a/vendor/github.com/yamamoto-febc/go-arukas/LICENSE.txt
+++ b/vendor/github.com/yamamoto-febc/go-arukas/LICENSE.txt
@@ -203,5 +203,5 @@
 
 ================================================================================
 
-   Copyright 2018 Kazumichi Yamamoto.
+   Copyright 2018-2019 Kazumichi Yamamoto.
 

--- a/vendor/github.com/yamamoto-febc/go-arukas/Makefile
+++ b/vendor/github.com/yamamoto-febc/go-arukas/Makefile
@@ -3,15 +3,14 @@ GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 CURRENT_VERSION = $(gobump show -r )
 GO_FILES?=$(shell find . -name '*.go')
 
+export GO111MODULE=on
+
 .PHONY: default
 default: test
 
 .PHONY: tools
 tools:
-	go get -u github.com/golang/dep/cmd/dep
 	go get -u github.com/motemen/gobump
-	go get -v github.com/alecthomas/gometalinter
-	gometalinter --install
 
 .PHONY: testacc
 testacc: 
@@ -20,11 +19,6 @@ testacc:
 .PHONY: test
 test: 
 	TEST_ACC=  go test ./... $(TESTARGS) -v -timeout=30m -parallel=4 ;
-
-.PHONY: lint
-lint: fmt
-	gometalinter --vendor --skip=vendor/ --cyclo-over=15 --disable=gas --deadline=2m ./...
-	@echo
 
 .PHONY: fmt
 fmt:

--- a/vendor/github.com/yamamoto-febc/go-arukas/README.md
+++ b/vendor/github.com/yamamoto-febc/go-arukas/README.md
@@ -15,7 +15,7 @@ This project provides various Go packages to perform operations on [`Arukas`](ht
 
 ## License
 
- `go-arukas` Copyright (C) 2018 Kazumichi Yamamoto.
+ `go-arukas` Copyright (C) 2018-2019 Kazumichi Yamamoto.
 
   This project is published under [Apache 2.0 License](LICENSE.txt).
   

--- a/vendor/github.com/yamamoto-febc/go-arukas/client.go
+++ b/vendor/github.com/yamamoto-febc/go-arukas/client.go
@@ -227,7 +227,12 @@ func (c *client) PowerOn(id string) error {
 	}
 	path := fmt.Sprintf("/services/%s/power", id)
 	_, err := c.httpAPI.post(path, nil)
-	return err
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(time.Second) // HACK
+	return nil
 }
 
 func (c *client) PowerOff(id string) error {

--- a/vendor/github.com/yamamoto-febc/go-arukas/request_param.go
+++ b/vendor/github.com/yamamoto-febc/go-arukas/request_param.go
@@ -12,7 +12,7 @@ type RequestParam struct {
 	CustomDomains []string
 	Image         string
 	Instances     int32
-	Ports         []*Port
+	Ports         Ports
 	Environment   []*Env
 	SubDomain     string
 	Region        string

--- a/vendor/github.com/yamamoto-febc/go-arukas/service.go
+++ b/vendor/github.com/yamamoto-febc/go-arukas/service.go
@@ -9,7 +9,7 @@ type ServiceListData struct {
 
 // Service represents service object
 type Service struct {
-	ID            string               `json:"id"`
+	ID            string               `json:"id,omitempty"`
 	LinkID        int32                `json:"lid,omitempty"`
 	Type          string               `json:"type,omitempty"`
 	Attributes    *ServiceAttr         `json:"attributes,omitempty"`
@@ -52,7 +52,7 @@ func (s *Service) Environment() []*Env {
 }
 
 // Ports returns data.attributes.ports
-func (s *Service) Ports() []*Port {
+func (s *Service) Ports() Ports {
 	return s.Attributes.Ports
 }
 
@@ -117,7 +117,7 @@ type ServiceAttr struct {
 	EndPoint                 string           `json:"endpoint,omitempty"`
 	CustomDomains            []*CustomDomain  `json:"custom-domains,omitempty"`
 	LastInstanceFailedAt     *time.Time       `json:"last-instance-failed-at,omitempty"`
-	LastInstanceFailedStatus string           `json:"last-instance-failed-status,omitempty"`
+	LastInstanceFailedStatus interface{}      `json:"last-instance-failed-status,omitempty"`
 }
 
 // ServiceData represents service data
@@ -171,7 +171,7 @@ func (s *ServiceData) Environment() []*Env {
 }
 
 // Ports returns data.attributes.ports
-func (s *ServiceData) Ports() []*Port {
+func (s *ServiceData) Ports() Ports {
 	return s.Data.Ports()
 }
 

--- a/vendor/github.com/yamamoto-febc/go-arukas/types.go
+++ b/vendor/github.com/yamamoto-febc/go-arukas/types.go
@@ -2,6 +2,7 @@ package arukas
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -44,6 +45,11 @@ type Port struct {
 	// Number is port number that container exposes.
 	// Valid value range is [1 - 65535]
 	Number int32 `json:"number"`
+}
+
+// MarshalJSON implements json.Marshaler
+func (p *Port) MarshalJSON() ([]byte, error) {
+	return json.Marshal(fmt.Sprintf("%d/%s", p.Number, p.Protocol))
 }
 
 // Ports is a slice of Ports. A service can have multiple ports.

--- a/vendor/github.com/yamamoto-febc/go-arukas/version.go
+++ b/vendor/github.com/yamamoto-febc/go-arukas/version.go
@@ -1,4 +1,4 @@
 package arukas
 
 // Version returns current version
-var Version = "0.0.7"
+var Version = "0.1.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -162,7 +162,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 github.com/ulikunitz/xz/internal/hash
-# github.com/yamamoto-febc/go-arukas v0.0.8
+# github.com/yamamoto-febc/go-arukas v0.1.0
 github.com/yamamoto-febc/go-arukas
 # github.com/zclconf/go-cty v0.0.0-20180718220526-02bd58e97b57
 github.com/zclconf/go-cty/cty


### PR DESCRIPTION
(depends on #8)

This PR upgrades go-arukas to v0.1.0 for fix acceptance-test failure.

Prior to go-arukas v0.1.0, Arukas API `POST /api/services/{SERVICE_ID}/power` always causes error.
go-arukas v0.1.0 solved this issue by adjusting API call timing.

#### Acceptance test result

```console
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-arukas	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccArukasContainer_Basic
--- PASS: TestAccArukasContainer_Basic (56.75s)
=== RUN   TestAccArukasContainer_Update
--- PASS: TestAccArukasContainer_Update (152.82s)
=== RUN   TestAccArukasContainer_Minimum
--- PASS: TestAccArukasContainer_Minimum (76.39s)
=== RUN   TestAccArukasContainer_Import
--- PASS: TestAccArukasContainer_Import (76.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-arukas/arukas	362.441s
```